### PR TITLE
quick and dirty fix build crosstool for arm from scratch

### DIFF
--- a/make/crosstool-arm.mk
+++ b/make/crosstool-arm.mk
@@ -27,7 +27,7 @@ CROSSTOOL = crosstool
 crosstool: crosstool-ng
 
 $(ARCHIVE)/$(CROSSTOOL_NG_SOURCE):
-	get-git-archive.sh $(CROSSTOOL_NG_URL) $(CROSSTOOL_NG_VER) $(notdir $@) $(ARCHIVE)
+	scripts/get-git-archive.sh $(CROSSTOOL_NG_URL) $(CROSSTOOL_NG_VER) $(notdir $@) $(ARCHIVE)
 
 crosstool-ng: directories $(ARCHIVE)/$(KERNEL_SRC) $(ARCHIVE)/$(CROSSTOOL_NG_SOURCE)
 	make $(BUILD_TMP)


### PR DESCRIPTION
get-git-archive.sh https://github.com/crosstool-ng/crosstool-ng.git 1dbb06f2 crosstool-ng-1dbb06f2.tar.bz2 /home/ezak/Archive
/bin/bash: get-git-archive.sh: command not found
make/crosstool-arm.mk:30: die Regel für Ziel „/home/ezak/Archive/crosstool-ng-1dbb06f2.tar.bz2“ scheiterte
make: *** [/home/ezak/Archive/crosstool-ng-1dbb06f2.tar.bz2] Fehler 127
